### PR TITLE
chore(go): add toolchain directive to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module log_exporter
 
 go 1.26
+toolchain go1.26.4
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
Adds an explicit toolchain directive to go.mod that matches the existing go version (go1.26.4). See Go toolchain management docs: https://go.dev/doc/toolchain